### PR TITLE
Fix Firestore results being limited to 20 items

### DIFF
--- a/api/partners.js
+++ b/api/partners.js
@@ -37,8 +37,10 @@ export default createHandler({
 			const results = await getCollectionItemsWhere(STORE, 'lastUpdated', '>', lastUpdated);
 			return Response.json(results.map(transformPartner));
 		} else {
-			const partners = await getCollectionItems(STORE, { limit: 100 });
+			const partners = await getCollectionItems(STORE, { limit: NaN });
 			return Response.json(partners.map(transformPartner), { headers });
 		}
 	},
+}, {
+	logger: err => console.error(err),
 });

--- a/api/utils.js
+++ b/api/utils.js
@@ -59,7 +59,9 @@ export async function getCollectionItems(name, {
 		  });
 	}
 
-	const snapshot = await query.offset((page - 1) * limit).limit(limit).get();
+	const snapshot = Number.isSafeInteger(limit) && limit > 0
+		? await query.offset((page - 1) * limit).limit(limit).get()
+		: await query.get();
 
 	return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
 }

--- a/js/routes/partners.js
+++ b/js/routes/partners.js
@@ -80,6 +80,7 @@ export const ORG_CATEGORIES = [
 	'Borel Fire',
 	'Homelessness',
 	'Elected Officials',
+	'Public Safety',
 ].sort();
 
 const linkIcon = `<svg class="icon" width="18" height="18" fill="currentColor" aria-label="Website">


### PR DESCRIPTION
Not exactly sure why this was, but support `limit` being unset/NaN/null.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
