### PR TITLE
Add holiday and weekend closure logic to pantry form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add support for more complex pantry schedules (closed days, different hours)
+
 ## [v1.1.10] - 20205-07-30
 
 ### Changed


### PR DESCRIPTION
Introduces OPENING_HOURS and CLOSED date lists to disable date/time selection on holidays and weekends. Refactors date handling and validation to ensure users can only select valid dates and times when the pantry is open. Updates form input attributes and labels for clarity.

Resolves #321
