### PR TITLE
Add schema.org microdata and update pantry info

### DIFF
--- a/js/routes/pantry.js
+++ b/js/routes/pantry.js
@@ -141,6 +141,8 @@ const TIMEZONE_OFFSET = 8 * HOURS;
 const TOWNS = ['South Lake', 'Weldon', 'Mt Mesa', 'Lake Isabella', 'Bodfish', 'Wofford Heights', 'Kernville'];
 const ZIPS = [95949, 93240, 93283, 93205, 93285, 93238, 93255, 93518];
 
+const timeFormatter = new Intl.DateTimeFormat(navigator.language, { timeStyle: 'short' });
+
 const dateChange = registerCallback('pantry:date:change', ({ target }) => {
 	if (target.value.length !== 10) {
 		target.setCustomValidity('Please select a valid date. YYYY-MM-DD format is required.');
@@ -245,9 +247,12 @@ export default function({
 	const maxDate = new Date(Date.now() + 2 * WEEKS);
 	const { min, max, disabled } = getOpeningHours(date);
 
-	return html`<form id="pantry-form" ${onSubmit}="${submitHandler}" ${onReset}="${resetHandler}" ${onChange}="${changeHandler}" ${signalAttr}="${sig}">
+	return html`<form id="pantry-form" itemtype="https://schema.org/ContactPoint" itemscope="" ${onSubmit}="${submitHandler}" ${onReset}="${resetHandler}" ${onChange}="${changeHandler}" ${signalAttr}="${sig}">
 		<div>
-			<h2>KRV Bridge Choice Food Pantry</h2>
+			<h2>
+				<span itemprop="name">KRV Bridge Connection</span>
+				<sapn itemprop="contactType">Choice Food Pantry</span>
+			</h2>
 			<img srcset="https://i.imgur.com/h68vmgFt.jpeg 90w,
 					https://i.imgur.com/h68vmgFm.jpeg 160w,
 					https://i.imgur.com/h68vmgFl.jpeg 320w,
@@ -262,11 +267,14 @@ export default function({
 				loading="lazy"
 				decoding="async"
 				crossorigin="anonymous"
+				itemprop="image"
 				referrerpolicy="no-referrer" />
-			<p>The Choice Pantry is provided to KRV residents to compliment other resources to meet nutritional needs.
-			As a choice pantry, it offers an experience more like shipping where guests are allowed to pick out their own
+			<p itemprop="description">Our Choice Pantry is designed to provide emergency food assistance. It's for community members who are facing a
+			temporary food crisis and need help filling the gaps when other resources, like SNAP benefits and food distributions,
+			are not enough.</p>
+			<p>As a choice pantry, it offers an experience more like shipping where guests are allowed to pick out their own
 			food that they want rather than a preset box of items.
-			The Choice Pantry is available up to twice per month and provides food based on household size.</p>
+			The Choice Pantry is available up to twice within a rolling one-month period and provides food based on household size.</p>
 		</div>
 		<div>
 			<h3>Notice</h3>
@@ -282,9 +290,32 @@ export default function({
 				</a>
 			</p>
 		</div>
+		<section class="pantry-general-hours">
+			<h3>General Pantry Hours</h3>
+			<p>Please be aware that this schedule does not reflect closures due to holidays or unexpected circumstances.</p>
+			<ul>
+				${OPENING_HOURS.map(({ dayOfWeek, opens, closes }) => `<li itemprop="hoursAvailable" itemtype="https://schema.org/OpeningHoursSpecification" itemscope="">
+					<span itemprop="dayOfWeek">${dayOfWeek}</span>
+					${typeof opens === 'string' && typeof closes === 'string' /* eslint-disable indent */
+						? `<time itemprop="opens" datetime="${opens}">${timeFormatter.format(new Date(`2025-08-29T${opens}`))}</time> &mdash; <time itemprop="closes" datetime="${closes}">${timeFormatter.format(new Date(`2025-08-29T${closes}`))}</time>`
+						: '<meta itemprop="opens" content="00:00" /><meta itemprop="closes" content="00:00" /><strong>Closed</strong>' /* eslint-enable indent */}
+				</li>`).join('')}
+			</ul>
+		</section>
+		<section itemprop="address" itemtype="https://schema.org/PostalAddress" itemscope="">
+			<h3>Address</h3>
+			<div itemprop="streetAddress">6069 Lake Isabella Blvd.</div>
+			<div>
+				<span itemprop="addressLocality">Lake Isabella</span>,
+				<span itemprop="addressRegion">CA</span>
+				<meta itemprop="postalCode" content="93240" />
+				<meta itemprop="addressCountry" content="US" />
+			</div>
+		</section>
 		<fieldset class="no-border">
 			<legend>Schedule an Appointment</legend>
-			<p>No appointment necessary, but we would appreciate the notice to ensure someone is available to assist you.</p>
+			<p>To ensure we can serve you, an appointment is required. Using this form is the only way to see our most up-to-date hours,
+			as we quickly update it to reflect any unexpected closures, such as those caused by low food inventory or other issues.</p>
 			<p class="status-box info">Fields marked with a <q>*</q> are required</p>
 			<div class="form-group flex wrap space-between">
 				<span>
@@ -311,7 +342,7 @@ export default function({
 			<div class="form-group">
 				<label for="pantry-street-address" class="input-label">Address</label>
 				<input type="text" name="streetAddress" id="pantry-street-address" class="input" autocomplete="street-address" placeholder="Street Address" ${attr({ value: streetAddress })} />
-				<label for="pantry-address-locality required" class="input-label required">City</label>
+				<label for="pantry-address-locality" class="input-label required">City</label>
 				<input type="text" name="addressLocality" id="pantry-address-locality" class="input" placeholder="Town" autocomplete="address-level2" list="pantry-towns-list" ${attr({ value: addressLocality })} ${onChange}="${updateZip}" required="" />
 				<datalist id="pantry-towns-list">
 					${TOWNS.map(town => `<option label="${town}" value="${town}"></option>`).join('\n')}


### PR DESCRIPTION
Introduces schema.org microdata for improved SEO and structured data, including ContactPoint, OpeningHoursSpecification, and PostalAddress. Updates pantry description, general hours, and address details, and clarifies appointment requirements and instructions for users.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
