### PR TITLE
Fix admin check in getOpeningHours function

### DIFF
--- a/js/routes/pantry.js
+++ b/js/routes/pantry.js
@@ -55,7 +55,7 @@ const CLOSED = [
 const getOpeningHours = (date) => {
 	if (CLOSED.includes(date.toISOString().split('T')[0])) {
 		return { disabled: true, min: null, max: null };
-	} else if (history.state.isAdmin) {
+	} else if (history.state?.isAdmin) {
 		const day = date.getDay();
 
 		return day === 0 || day === 6 || Number.isNaN(day)


### PR DESCRIPTION
Replaces direct access to history.state.isAdmin with optional chaining to prevent errors when history.state is undefined.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
