### PR TITLE
Add CalFresh benefits link to pantry page

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -1,7 +1,7 @@
 <aside id="sidebar" class="card">
 	<weather-current appid="{{ keys.weather }}" postalcode="93240"></weather-current>
 	<br />
-	<krv-events></krv-events>
+	<krv-events source="krv-bridge"></krv-events>
 	{% if pinned-posts %}{% include "11ty-articles/pinned-posts.html" count: layout.pinned-posts %}{% endif %}
 	<!-- {% if page.ads %}{% for ad in page.ads %} -->
 	<!-- 	{% include "11ty-common/krv-ad.html" ad: ad content: "sidebar" %} -->

--- a/js/routes/pantry.js
+++ b/js/routes/pantry.js
@@ -16,6 +16,7 @@ const style = css`#pantry-date:not(:invalid) + #pantry-date-invalid,
 	visibility: hidden;
 }`;
 
+const CAL_BENEFITS = 'https://benefitscal.com/';
 const CARES_FORM = '/docs/cares-form.pdf';
 
 const date = getSearch('date', '');
@@ -300,6 +301,16 @@ export default function({
 			<p>As a choice pantry, it offers an experience more like shipping where guests are allowed to pick out their own
 			food that they want rather than a preset box of items.
 			The Choice Pantry is available up to twice within a rolling one-month period and provides food based on household size.</p>
+			<p>
+				Apply for food assistance in California through the official
+				<a href="${CAL_BENEFITS}" class="btn btn-link" target="_blank" rel="noopener noreferrer">
+					<span>CalFresh (SNAP/Food Stamps)</span>
+					<svg class="icon" width="18" height="18" fill="currentColor" role="presentation" aria-hidden="true">
+						<use href="/img/icons.svg#link-external"></use>
+					</svg>
+				</a>
+				website.
+			</p>
 		</div>
 		<section aria-labelledby="pantry-hud-notice" hidden="">
 			<h3 id="pantry-hud-notice">Notice</h3>


### PR DESCRIPTION
Introduces a link to the official CalFresh (SNAP/Food Stamps) website for food assistance in California on the pantry route. Also updates the sidebar to specify the source for krv-events.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
