### PR TITLE
Add closure notice to pantry route

### DIFF
--- a/js/routes/pantry.js
+++ b/js/routes/pantry.js
@@ -16,6 +16,7 @@ const style = css`#pantry-date:not(:invalid) + #pantry-date-invalid,
 	visibility: hidden;
 }`;
 
+const MESSAGE = 'Our Emergency Choice Pantry is currently closed due to the canyon having been closed. Please see <a href="https://events.kernvalley.us/2025/09/25/hunger-action-month-pantry-stocking">Hunger Action Month Pantry Stocking</a> if you are able to help.';
 const CAL_BENEFITS = 'https://benefitscal.com/';
 const CARES_FORM = '/docs/cares-form.pdf';
 
@@ -283,6 +284,7 @@ export default function({
 				<span itemprop="name">KRV Bridge Connection</span>
 				<sapn itemprop="contactType">Choice Food Pantry</span>
 			</h2>
+			${typeof MESSAGE === 'string' ? `<div class="status-box info"><p>${MESSAGE}</p></div><br />` : '' }
 			<img srcset="https://i.imgur.com/h68vmgFt.jpeg 90w,
 					https://i.imgur.com/h68vmgFm.jpeg 160w,
 					https://i.imgur.com/h68vmgFl.jpeg 320w,


### PR DESCRIPTION
Introduces a MESSAGE constant to display a closure notice for the Emergency Choice Pantry due to canyon closure, with a link to Hunger Action Month Pantry Stocking for assistance.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
