### PR TITLE
Update CloseWatcher event and confirmation logic

### DIFF
--- a/js/routes/pantry-distribution.js
+++ b/js/routes/pantry-distribution.js
@@ -455,12 +455,14 @@ export default async function({
 	const closeWatcher = new CloseWatcher({ signal });
 	OTHER_ELS.forEach(id => document.getElementById(id).inert = true);
 
-	closeWatcher.addEventListener('close', async () => {
-		if (await confirm('Exit page?')) {
+	closeWatcher.addEventListener('cancel', (event) => {
+		if (globalThis.confirm('Exit page?')) {
 			closeWatcher.destroy();
-			await navigate('/');
-			unlock();
 			OTHER_ELS.forEach(id => document.getElementById(id).inert = false);
+			navigate('/');
+			unlock();
+		} else {
+			event.preventDefault();
 		}
 	}, { signal });
 


### PR DESCRIPTION
Changed CloseWatcher event listener from 'close' to 'cancel', replaced async confirm with globalThis.confirm, and improved event handling to prevent default action when user cancels exit.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
