### PR TITLE
Tighten npm install source restrictions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,4 @@
 strict-allow-scripts=true
+allow-git=none
+allow-remote=none
+allow-file=none


### PR DESCRIPTION
Update .npmrc to disable non-registry package sources by adding allow-git=none, allow-remote=none, and allow-file=none. This complements strict-allow-scripts=true to reduce supply-chain risk by preventing installs from git URLs, remote locations, and local file paths.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
