### PR TITLE
Update pantry page and digital signage

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,6 @@ repos:
   hooks:
   - id: local-eslint
     name: Run ESLint
-    entry: npm eslint --fix
+    entry: npm run lint:js
     language: system
     types_or: [javascript, jsx, ts, tsx]

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@ description: Our mission is to bridge individuals and families to services that 
 <section id="actions">
 	<h2>I want to...</h2>
 	<div class="flex row wrap space-evenly home-ctas">
-		<a href="/calendar/pantry" class="cta block color-default center">
+		<a href="/pantry/" class="cta block color-default center">
 			<span class="cta-label">Find Food</span>
 			{% include "11ty-common/icon.html" icon: "food" height: 96 width: 96 fill: "currentColor" class: "cta-icon" %}
 		</a>

--- a/js/routes/digital-signage.js
+++ b/js/routes/digital-signage.js
@@ -230,7 +230,7 @@ export default async ({ signal, stack }) => {
 		cal,
 		forecast,
 		el`<img src="https://i.imgur.com/abU36k3.webp" width="1305" height="729" alt="Diabetic Cooking Class" crossorigin="anonymous" referrerpolicy="anonymous" decoding="lazy" loading="lazy" />`,
-		GCalEvents.create('pantry', { loading: 'lazy', theme: 'dark' }),
+		// GCalEvents.create('pantry', { loading: 'lazy', theme: 'dark' }),
 		el`<img src="https://i.imgur.com/iJTxGeL.webp" width="1376" height="768" alt="Volunteer with KRV Bridge Connection!" crossorigin="anonymous" referrerpolicy="no-referrer" loading="lazy" />` ,
 		GCalEvents.create('partners', { loading: 'lazy', theme: 'dark' }),
 		el`<div>

--- a/js/routes/pantry.js
+++ b/js/routes/pantry.js
@@ -5,8 +5,6 @@ import { css } from '@aegisjsproject/core/parsers/css.js';
 const CAL_BENEFITS = 'https://benefitscal.com/';
 const MESSAGE = null;
 
-const placehodler = '_' + crypto.randomUUID();
-
 export const styles = css`#pantry-message {
 	max-width: min(800px, 95%);
 }
@@ -17,11 +15,7 @@ export const styles = css`#pantry-message {
 }`;
 
 export default async () => {
-
-	/**
-	 * @type {DocumentFragment}
-	 */
-	const frag = html`<section aria-labelledby="pantry-header">
+	return html`<section aria-labelledby="pantry-header">
 		<h3>Emergency Choice Pantry</h3>
 		${typeof MESSAGE === 'string' ? `<div class="status-box info"><p>${MESSAGE}</p></div><br />` : '' }
 		<img srcset="https://i.imgur.com/h68vmgFt.jpeg 90w,
@@ -57,6 +51,27 @@ export default async () => {
 			website.
 		</p>
 	</section>
+	<section class="pantry-general-hours" aria-labelledby="general-pantry-hours">
+		<h3 id="general-pantry-hours">General Pantry Hours</h3>
+		<p>
+			<span>Salvation Army posts weekly schedules on their</span>
+			<a href="https://www.facebook.com/profile.php?id=61574323912303" rel="noopener noreferrer external" target="_blank" class="btn btn-link">
+				<span>Facebook Page</span>
+				<svg xmlns="http://www.w3.org/2000/svg" width="12" height="16" viewBox="0 0 12 16" class="icon" fill="currentColor" role="presentation" aria-hidden="true">
+					<path fill-rule="evenodd" d="M11 10h1v3c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h3v1H1v10h10v-3zM6 2l2.25 2.25L5 7.5 6.5 9l3.25-3.25L12 8V2H6z"/>
+				</svg>
+			</a>.
+		</p>
+		<p>
+			<span>For all questions regarding the Salvation Army Choice Pantry, place call</span>
+				<a href="tel:+1-760-417-3056" class="btn btn-primary">
+					<svg height="16" width="16" viewBox="0 0 16 16" class="icon" fill="currentColor" role="presentation" aria-hidden="true">
+						 <path d="M13.032 1c.534 0 .969.427.969.969v.062c-.017 6.613-5.383 11.97-12 11.97H1.97c-.545 0-.97-.447-.97-1v-3c0-.555.447-1 1-1h2c.555 0 1 .445 1 1v.468A8.967 8.967 0 0 0 10.47 5H10c-.553 0-1-.446-1-1V2c0-.554.447-1 1-1h3.032z"/>
+					</svg>
+					<span>(760) 417-3056</span>
+				</a>.
+			</p>
+	</section>
 	<section itemprop="address" itemtype="https://schema.org/PostalAddress" aria-labelledby="pantry-address" itemscope="">
 		<meta itemprop="name" content="KRV Bridge Connection" />
 		<h3 id="pantry-address">Address</h3>
@@ -67,18 +82,7 @@ export default async () => {
 			<meta itemprop="postalCode" content="93240" />
 			<meta itemprop="addressCountry" content="US" />
 		</div>
-	</section>
-	<section class="pantry-general-hours" aria-labelledby="general-pantry-hours">
-		<h3 id="general-pantry-hours">General Pantry Hours</h3>
-		<p>The following calendar shows the pantry and distribution hours provided by the organizations. Please check the dates, times, and locations carefully.</p>
-		<div id="${placehodler}"></div>
 	</section>`;
-
-	const GCal = await customElements.whenDefined('g-cal-events');
-	const cal = GCal.create('pantry', { loading: 'lazy' });
-	cal.classList.add('calendar');
-	frag.getElementById(placehodler).replaceWith(cal);
-	return frag;
 };
 
 export const title = `Emergency Choice Food Pantry - ${site.title}`;


### PR DESCRIPTION
Fix pantry link in index, add general hours/contact info to pantry route, and simplify pantry rendering. pantry.js: remove unused UUID placeholder and dynamic fragment/calendar injection; return the HTML directly and add a "General Pantry Hours" section with Facebook and phone contact. digital-signage.js: disable the embedded 'pantry' GCalEvents (commented out) to avoid rendering the calendar on signage. Minor markup/whitespace adjustments in index.html and pantry.js.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
