### PR TITLE
Fix cookie path handling and update lambda-http Removed manual cookie path concatenation and fixed cookie initialization in partners.js. The Cookie constructor now properly handles the path parameter directly. Updated @shgysk8zer0/lambda-http to v1.2.3. Also improved comments clarifying why path and httpOnly are set, and fixed unnecessary parentheses in date parsing.

### DIFF
--- a/api/orgJWT.js
+++ b/api/orgJWT.js
@@ -75,7 +75,9 @@ export default createHandler({
 					partitioned,
 				});
 
-				return Response.json({ expires, jti }, { headers: new Headers({ 'Set-Cookie': cookie }) });
+				return Response.json({ expires, jti }, {
+					headers: new Headers({ 'Set-Cookie': cookie }),
+				});
 			} else {
 				throw new HTTPNotFoundError(`No user record exists for user ${uid}.`);
 			}

--- a/api/partners.js
+++ b/api/partners.js
@@ -19,13 +19,13 @@ function transformPartner({ lastUpdated, keywords, hoursAvailable = {}, ...data 
 const getCookie = () => new Cookie({
 	name: COOKIE_NAME,
 	value: Date.now(),
-	// path: '/', // Seems to be a bug setting a path of "/", so adding it manually
-	httpOnly: false,
+	path: '/', // Needs to be accessible from any page
+	httpOnly: false, // So that client can check if sync is due
 	sameSite: 'strict',
 	secure: true,
 	expires: new Date(Date.now() + 15724800000), // + 182 days
 	partitioned: true,
-}) + '; Path=/;';
+});
 
 export default createHandler({
 	async get(req) {
@@ -44,7 +44,7 @@ export default createHandler({
 			const results = await getCollectionItemsWhere(STORE, 'keywords', 'array-contains', params.get('category').toLowerCase());
 			return Response.json(results.map(transformPartner), { status: results.length === 0 ? 404 : 200 }, { headers });
 		} else if (req.cookies.has(COOKIE_NAME)) {
-			const lastUpdated = new Date((parseInt(req.cookies.get(COOKIE_NAME)) || 0));
+			const lastUpdated = new Date(parseInt(req.cookies.get(COOKIE_NAME)) || 0);
 			const results = await getCollectionItemsWhere(STORE, 'lastUpdated', '>', lastUpdated);
 			headers.set('Set-Cookie', getCookie());
 			return Response.json(results.map(transformPartner), { headers });

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@shgysk8zer0/aes-gcm": "^1.1.0",
         "@shgysk8zer0/geoutils": "^1.0.6",
         "@shgysk8zer0/importmap": "^1.10.2",
-        "@shgysk8zer0/lambda-http": "^1.2.1",
+        "@shgysk8zer0/lambda-http": "^1.2.3",
         "@shgysk8zer0/netlify-func-utils": "^1.1.2",
         "@shgysk8zer0/slack": "^0.0.7",
         "@shgysk8zer0/suid": "^1.0.0",
@@ -7823,9 +7823,9 @@
       }
     },
     "node_modules/@shgysk8zer0/lambda-http": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@shgysk8zer0/lambda-http/-/lambda-http-1.2.1.tgz",
-      "integrity": "sha512-+3v6UqJhoJtNc/C0rPcv9VXNuWy0QMYLU41kogjrM//nkkFFj9LF7O68DLNGAPhTLtO2Z0wOBqcbvPNMTJjAyQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@shgysk8zer0/lambda-http/-/lambda-http-1.2.3.tgz",
+      "integrity": "sha512-izpvcQ058u3NHdGgYNni9Ok3rZvIuu6JaPne0p+Z4tRzYuca/lGT94l+94QxNRL25glRxawDCJxlcmiwu6djqA==",
       "funding": [
         {
           "type": "librepay",

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@shgysk8zer0/aes-gcm": "^1.1.0",
     "@shgysk8zer0/geoutils": "^1.0.6",
     "@shgysk8zer0/importmap": "^1.10.2",
-    "@shgysk8zer0/lambda-http": "^1.2.1",
+    "@shgysk8zer0/lambda-http": "^1.2.3",
     "@shgysk8zer0/netlify-func-utils": "^1.1.2",
     "@shgysk8zer0/slack": "^0.0.7",
     "@shgysk8zer0/suid": "^1.0.0",


### PR DESCRIPTION
# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
